### PR TITLE
jdk 11 compatibility fix using toArray type hint

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,7 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        org.clojure/clojurescript {:mvn/version "1.10.520"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {com.cognitect/test-runner
+                               {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                :sha "028a6d41ac9ac5d5c405dfc38e4da6b4cc1255d5"}
+                               org.clojure/test.check {:mvn/version "0.9.0"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   know their context"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-beta1"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "0.0-3196"]]
-  :profiles {:dev {:dependencies [[org.clojure/test.check "0.6.3-SNAPSHOT"]]
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]
                    :plugins [[lein-cljsbuild "1.0.5"]
                              [com.cemerick/clojurescript.test "0.3.3"]]
                    :aliases {"test-all" ["do" "test," "cljsbuild" "test"]}
@@ -13,6 +13,6 @@
                                :builds [{:source-paths ["src" "test"]
                                          :compiler {:output-to "target/test-runner.js"
                                                     :optimizations :whitespace
-                                                    :pretty-print true}}]}}}
-  )
+                                                    :pretty-print true}}]}}})
+  
 

--- a/src/contextual/core.cljc
+++ b/src/contextual/core.cljc
@@ -289,7 +289,7 @@
      (isEmpty [_] (.isEmpty delegate))
      (size [_] (.size delegate))
      (toArray [this] (clojure.lang.RT/seqToArray (seq this)))
-     (toArray [this a] (clojure.lang.RT/seqToPassedArray (seq this) a))
+     (^"[Ljava.lang.Object;" toArray [this ^"[Ljava.lang.Object;" a] (clojure.lang.RT/seqToPassedArray (seq this) a))
 
      java.util.List
      (get [_ idx] (contextual-value path idx (.get delegate idx)))
@@ -305,8 +305,8 @@
      (subList [_ from to]
        (->DelegateVec (.subList delegate from to) path))
 
-     java.util.RandomAccess
-     ))
+     java.util.RandomAccess))
+     
 
 #? (:cljs
     (deftype DelegateVec [delegate path]

--- a/src/contextual/core.cljc
+++ b/src/contextual/core.cljc
@@ -63,7 +63,7 @@
     entry))
 
 #?(:clj
-   (deftype DelegateMap [delegate path]
+   (deftype DelegateMap [^clojure.lang.IPersistentMap delegate path]
      Contextual
      (context [_] path)
      (decontextualize [_] delegate)
@@ -117,7 +117,7 @@
      java.io.Serializable
 
      java.lang.Iterable
-     (iterator [this] (.iterator (seq this)))
+     (iterator [this] (.iterator ^java.lang.Iterable (seq this)))
 
      java.lang.Runnable
      (run [this] (.invoke this))
@@ -198,7 +198,7 @@
 
 #?(:clj
 
-   (deftype DelegateVec [delegate path]
+   (deftype DelegateVec [^clojure.lang.IPersistentVector delegate path]
      Contextual
      (context [_] path)
      (decontextualize [_] delegate)
@@ -248,7 +248,7 @@
      java.io.Serializable
 
      java.lang.Iterable
-     (iterator [this] (.iterator (seq this)))
+     (iterator [this] (.iterator ^java.lang.Iterable (seq this)))
 
      java.lang.Runnable
      (run [this] (.invoke this))
@@ -299,9 +299,9 @@
        ;; This is quite inefficent, but much easier to
        ;; implement. Should be enough of an edge case that it doesn't
        ;; matter.
-       (.listIterator (vec (seq this))))
+       (.listIterator ^java.util.List (vec (seq this))))
      (listIterator [this i]
-       (.listIterator (vec (seq this)) i))
+       (.listIterator ^java.util.List (vec (seq this)) i))
      (subList [_ from to]
        (->DelegateVec (.subList delegate from to) path))
 


### PR DESCRIPTION
Projects that included previous versions of `contextual` fail on JDK 11 (possibly other post-8 versions) with errors like:

```
Caused by: java.lang.IllegalArgumentException: Must hint overloaded method: toArray
        at clojure.lang.Compiler$NewInstanceMethod.parse(Compiler.java:8496)
        at clojure.lang.Compiler$NewInstanceExpr.build(Compiler.java:8058)
        at clojure.lang.Compiler$NewInstanceExpr$DeftypeParser.parse(Compiler.java:7934)
        at clojure.lang.Compiler.analyzeSeq(Compiler.java:7106)
        ... 153 more
```

The error cause is described [here](https://www.deps.co/blog/how-to-upgrade-clojure-projects-to-use-java-11/#java-util-collection-toarray), this fix is identical to the one applied by `core-rrb.vector` [here](https://github.com/clojure/core.rrb-vector/commit/b489b3249d56bb6a104c2d4ead2da8ade8dd29b4).

Can confirm that all tests pass run through `lein test :all` and in the deps project, and that this resolves JDK 11 executing for jar on a project that depends on contextual.

Also on this PR:

- bump project.clj to no longer depend on missing `test.check` snapshot.
- bump project.clj to depend on Clojure 1.7.0 instead of beta.
- add minimal deps.edn for git coords.